### PR TITLE
feat: add support for passing encoder/decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A convinience-wrapper arround protocol-buffers and lp-messages functions
 
 # API
 
-- `wrap(duplex)`: Wraps a duplex, returns below object
+- `wrap(duplex, opts)`: Wraps a duplex, returns below object (opts=Object with .lengthEncoder, .lengthDecoder from [it-length-prefixed api](https://www.npmjs.com/package/it-length-prefixed#api))
   - `.read(bytes)`: async, reads the given amount of bytes
   - `.readLP()`: async, reads one length-prefixed message
   - `.readPB(proto)`: async, reads one protocol-buffers length-prefixed message (proto=Object with .encode, .decode functions)

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,9 @@
 const Shake = require('it-handshake')
 const lp = require('it-length-prefixed')
 
-module.exports = (duplex) => {
+module.exports = (duplex, opts = {}) => {
   const shake = Shake(duplex)
-  const lpReader = lp.decode.fromReader(shake.reader)
+  const lpReader = lp.decode.fromReader(shake.reader, { lengthDecoder: opts.lengthDecoder })
 
   let isDone = false
 
@@ -24,7 +24,7 @@ module.exports = (duplex) => {
       if (!value) { throw new Error('Value is null') }
       return value
     },
-    readLP: async (useBE32) => {
+    readLP: async () => {
       // read, decode
       const { value, done } = await lpReader.next()
 
@@ -46,9 +46,9 @@ module.exports = (duplex) => {
       // just write
       shake.writer.push(data)
     },
-    writeLP: (data, useBE32) => {
+    writeLP: (data) => {
       // encode, write
-      W.write(lp.encode.single(data))
+      W.write(lp.encode.single(data, { lengthEncoder: opts.lengthEncoder }))
     },
     writePB: (data, proto) => {
       // encode, writeLP


### PR DESCRIPTION
This adds the ability to pass the lengthEncoder and lengthDecoder options for it-length-prefixed. I included tests for fixed encoding/decoding.

It's possible that the encoder could be passed to each individual write, but decoding from a reader doesn't currently support changing the decoder, so I made this a one time configuration when creating the wrap.