### PR TITLE
fix: read pb using read lp

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,9 +35,7 @@ module.exports = (duplex, opts = {}) => {
     },
     readPB: async (proto) => {
       // readLP, decode
-      const { value, done } = await W.readLP()
-
-      isDone = done
+      const value = await W.readLP()
 
       if (!value) { throw new Error('Value is null') }
       return proto.decode(value)

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,11 @@ module.exports = (duplex, opts = {}) => {
       const value = await W.readLP()
 
       if (!value) { throw new Error('Value is null') }
-      return proto.decode(value)
+
+      // Is this a buffer?
+      const buf = Buffer.isBuffer(value) ? value : value.slice()
+
+      return proto.decode(buf)
     },
     write: (data) => {
       // just write


### PR DESCRIPTION
`readPB` function was not working because it was using `readLP` internally but it was expecting the return of `lpReader.next()`, instead of the single value return. This PR aims to fix this.

Moreover, when decoding a protobuf, we need to guarantee that we are dealing with a Buffer, as this module also supports `BufferList`. This way, I also added a conversion to Buffer in the event of a BufferList being used.

@mkg20001 I noticed that you do not have tests for the PB API. It should be worth adding it in a new PR