### PR TITLE
Support for rest of it-length-prefixed opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A convinience-wrapper arround protocol-buffers and lp-messages functions
 
 # API
 
-- `wrap(duplex, opts)`: Wraps a duplex, returns below object (opts=Object with .lengthEncoder, .lengthDecoder from [it-length-prefixed api](https://www.npmjs.com/package/it-length-prefixed#api))
+- `wrap(duplex, opts)`: Wraps a duplex, returns below object (opts=Object with encode/decode opts from [it-length-prefixed api](https://www.npmjs.com/package/it-length-prefixed#api))
   - `.read(bytes)`: async, reads the given amount of bytes
   - `.readLP()`: async, reads one length-prefixed message
   - `.readPB(proto)`: async, reads one protocol-buffers length-prefixed message (proto=Object with .encode, .decode functions)

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,10 @@ const lp = require('it-length-prefixed')
 
 module.exports = (duplex, opts = {}) => {
   const shake = Shake(duplex)
-  const lpReader = lp.decode.fromReader(shake.reader, { lengthDecoder: opts.lengthDecoder })
+  const lpReader = lp.decode.fromReader(
+      shake.reader,
+      opts
+  )
 
   let isDone = false
 
@@ -50,7 +53,7 @@ module.exports = (duplex, opts = {}) => {
     },
     writeLP: (data) => {
       // encode, write
-      W.write(lp.encode.single(data, { lengthEncoder: opts.lengthEncoder }))
+      W.write(lp.encode.single(data, opts))
     },
     writePB: (data, proto) => {
       // encode, writeLP

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,37 @@ describe('it-pb-rpc', () => {
       const res = await wrap.readLP()
       assert.deepEqual(res.slice(), data)
     })
+
+    it('lp exceeds max length decode', async () => {
+      const duplex = Pair()
+      const wrap = Wrap(duplex, { lengthDecoder: int32BEDecode, maxDataLength: 32 })
+      const data = Buffer.alloc(33, 1);
+      const length = Buffer.allocUnsafe(4)
+      length.writeInt32BE(data.length, 0)
+      const encoded = Buffer.concat([length, data])
+
+      wrap.write(encoded)
+      try {
+        await wrap.readLP()
+        assert.fail("Should not be able to read too long msg data")
+      } catch (e) {
+        assert.ok(true);
+      }
+    })
+
+    it('lp max length decode', async () => {
+      const duplex = Pair()
+      const wrap = Wrap(duplex, { lengthDecoder: int32BEDecode, maxDataLength: 5000 })
+      const data = Buffer.allocUnsafe(4000);
+      const length = Buffer.allocUnsafe(4)
+      length.writeInt32BE(data.length, 0)
+      const encoded = Buffer.concat([length, data])
+
+      wrap.write(encoded)
+      const res = await wrap.readLP()
+      assert.deepEqual(res.slice(), data)
+    })
+
   })
 
   describe('plain data', async () => {


### PR DESCRIPTION
We need maxDataLength opt to support noise spec in libp2p but it would probably be useful to support all opts.

This will work as long it-length-prefixed has different opts for encode and decode but splitting opts seems messy.
