### PR TITLE
Fix missing param name in typescript definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,12 +4,12 @@ import {Buffer} from "buffer";
 type WrappedDuplex = {
     read(bytes?: number): Promise<BufferList>;
     readLP(): Promise<BufferList>;
-    readPB<T>(proto: {decode: (Buffer) => T}): Promise<T>;
+    readPB<T>(proto: {decode: (data: Buffer) => T}): Promise<T>;
     write(input: BufferList): void;
     writeLP(input: Buffer | BufferList): void;
     writePB(data: Buffer | BufferList, proto: {encode: (data: any) => Buffer}): void;
 
-    pb<Return>(proto: {encode: (data: any) => Buffer, decode: (Buffer) => Return}): {read: () => Return, write: (d: Buffer) => void}
+    pb<Return>(proto: {encode: (data: any) => Buffer, decode: (data: Buffer) => Return}): {read: () => Return, write: (d: Buffer) => void}
     //return vanilla duplex
     unwrap(): any;
 }


### PR DESCRIPTION
It seems like typescript 3.8 is complaining about this.