### PR TITLE
feat: support Uint8Arrays, Buffers and BufferLists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 yarn-error.log
 package-lock.json
 yarn.lock
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -17,11 +17,14 @@
   },
   "devDependencies": {
     "@types/bl": "^5.0.0",
+    "bl": "^5.0.0",
+    "buffer": "^6.0.3",
     "it-pair": "^1.0.0",
     "mkgs-tool": "^0.1.15",
     "mocha": "*",
     "nyc": "*",
-    "streaming-iterables": "^5.0.4"
+    "streaming-iterables": "^5.0.4",
+    "uint8arrays": "^3.0.0"
   },
   "dependencies": {
     "is-buffer": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -20,14 +20,11 @@
     "bl": "^5.0.0",
     "buffer": "^6.0.3",
     "it-pair": "^1.0.0",
-    "mkgs-tool": "^0.1.15",
     "mocha": "*",
     "nyc": "*",
-    "streaming-iterables": "^5.0.4",
     "uint8arrays": "^3.0.0"
   },
   "dependencies": {
-    "is-buffer": "^2.0.5",
     "it-handshake": "^2.0.0",
     "it-length-prefixed": "^5.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -16,17 +16,18 @@
     "cov": "nyc mocha"
   },
   "devDependencies": {
-    "@types/bl": "^5.0.0",
+    "@types/bl": "^5.0.2",
     "bl": "^5.0.0",
     "buffer": "^6.0.3",
     "it-pair": "^1.0.0",
     "mocha": "*",
     "nyc": "*",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "^3.0.0",
+    "mkgs-tool": "^0.1.23"
   },
   "dependencies": {
     "it-handshake": "^2.0.0",
-    "it-length-prefixed": "^5.0.2"
+    "it-length-prefixed": "^5.0.3"
   },
   "repository": {
     "type": "git",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,26 +1,25 @@
 import BufferList = require("bl");
-import {Buffer} from "buffer";
 
 type WrappedDuplex = {
     read(bytes?: number): Promise<BufferList>;
     readLP(): Promise<BufferList>;
-    readPB<T>(proto: {decode: (data: Buffer) => T}): Promise<T>;
+    readPB<T>(proto: {decode: (data: Uint8Array) => T}): Promise<T>;
     write(input: BufferList): void;
-    writeLP(input: Buffer | BufferList): void;
-    writePB(data: Buffer | BufferList, proto: {encode: (data: any) => Buffer}): void;
+    writeLP(input: Uint8Array | BufferList): void;
+    writePB(data: Uint8Array | BufferList, proto: {encode: (data: any) => Uint8Array}): void;
 
-    pb<Return>(proto: {encode: (data: any) => Buffer, decode: (data: Buffer) => Return}): {read: () => Return, write: (d: Buffer) => void}
+    pb<Return>(proto: {encode: (data: any) => Uint8Array, decode: (data: Uint8Array) => Return}): {read: () => Return, write: (d: Uint8Array) => void}
     //return vanilla duplex
     unwrap(): any;
 }
 
 declare interface LengthDecoderFunction {
-    (data: Buffer | BufferList): number;
+    (data: Uint8Array | BufferList): number;
     bytes: number;
 }
 
 declare interface LengthEncoderFunction {
-    (value: number, target: Buffer, offset: number): number|Buffer;
+    (value: number, target: Uint8Array, offset: number): number|Uint8Array;
     bytes: number;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ module.exports = (duplex, opts = {}) => {
       if (!value) { throw new Error('Value is null') }
 
       // Is this a buffer?
-      const buf = isBuffer(value) ? value : value.slice()
+      const buf = isBuffer(value) || value instanceof Uint8Array ? value : value.slice()
 
       return proto.decode(buf)
     },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const isBuffer = require('is-buffer')
 const Shake = require('it-handshake')
 const lp = require('it-length-prefixed')
 
@@ -43,8 +42,8 @@ module.exports = (duplex, opts = {}) => {
 
       if (!value) { throw new Error('Value is null') }
 
-      // Is this a buffer?
-      const buf = isBuffer(value) || value instanceof Uint8Array ? value : value.slice()
+      // Is this a Uint8Array?
+      const buf = value instanceof Uint8Array ? value : value.slice()
 
       return proto.decode(buf)
     },

--- a/test/index.js
+++ b/test/index.js
@@ -4,107 +4,151 @@ const Pair = require('it-pair')
 const Wrap = require('..')
 const assert = require('assert').strict
 const { int32BEDecode, int32BEEncode } = require('it-length-prefixed')
+const { BufferList } = require('bl')
+const { concat: uint8ArrayConcat } = require('uint8arrays/concat')
+const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
+const { Buffer } = require('buffer')
 
 /* eslint-env mocha */
 /* eslint-disable require-await */
 
-describe('it-pb-rpc', () => {
-  let pair
-  let w
+const assertBytesEqual = (a, b) => {
+  a = a.slice()
+  b = b.slice()
 
-  before(async () => {
-    pair = Pair()
-    w = Wrap(pair)
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      throw new Error(`Byte at index ${i} incorrect, expected ${a[i]}, got ${b[i]}`)
+    }
+  }
+}
+
+const tests = {
+  Buffer: {
+    from: (str) => Buffer.from(str),
+    alloc: (length, fill = 0) => Buffer.alloc(length, fill),
+    allocUnsafe: (length) => Buffer.allocUnsafe(length),
+    concat: (arrs, length) => Buffer.concat(arrs, length),
+    writeInt32BE: (buf, value, offset) => buf.writeInt32BE(value, offset)
+  },
+  Uint8Array: {
+    from: (str) => uint8ArrayFromString(str),
+    alloc: (length, fill = 0) => new Uint8Array(length).fill(fill),
+    allocUnsafe: (length) => new Uint8Array(length),
+    concat: (arrs, length) => uint8ArrayConcat(arrs, length),
+    writeInt32BE: (buf, value, offset) => new DataView(buf.buffer, buf.byteOffset, buf.byteLength).setInt32(offset, value, false)
+  },
+  BufferList: {
+    from: (str) => new BufferList(str),
+    alloc: (length, fill = 0) => new BufferList(Buffer.alloc(length, fill)),
+    allocUnsafe: (length) => new BufferList(Buffer.allocUnsafe(length)),
+    concat: (arrs, length) => new BufferList(Buffer.concat(arrs.map(arr => arr.slice()), length)),
+    writeInt32BE: (buf, value, offset) => buf.slice().writeInt32BE(value, offset)
+  }
+}
+
+Object.keys(tests).forEach(key => {
+  const test = tests[key]
+
+  describe(`it-pb-rpc ${key}` , () => {
+    let pair
+    let w
+
+    before(async () => {
+      pair = Pair()
+      w = Wrap(pair)
+    })
+
+    describe('length-prefixed', () => {
+      it('lp varint', async () => {
+        const data = test.from('hellllllllloooo')
+
+        w.writeLP(data)
+        const res = await w.readLP()
+        assertBytesEqual(data, res)
+      })
+
+      it('lp fixed encode', async () => {
+        const duplex = Pair()
+        const wrap = Wrap(duplex, { lengthEncoder: int32BEEncode })
+        const data = test.from('hellllllllloooo')
+
+        wrap.writeLP(data)
+        const res = await wrap.read()
+        const length = test.allocUnsafe(4)
+        test.writeInt32BE(length, data.length, 0)
+        const expected = test.concat([length, data])
+        assertBytesEqual(res, expected)
+      })
+
+      it('lp fixed decode', async () => {
+        const duplex = Pair()
+        const wrap = Wrap(duplex, { lengthDecoder: int32BEDecode })
+        const data = test.from('hellllllllloooo')
+        const length = test.allocUnsafe(4)
+        test.writeInt32BE(length, data.length, 0)
+        const encoded = test.concat([length, data])
+
+        wrap.write(encoded)
+        const res = await wrap.readLP()
+        assertBytesEqual(res, data)
+      })
+
+      it('lp exceeds max length decode', async () => {
+        const duplex = Pair()
+        const wrap = Wrap(duplex, { lengthDecoder: int32BEDecode, maxDataLength: 32 })
+        const data = test.alloc(33, 1);
+        const length = test.allocUnsafe(4)
+        test.writeInt32BE(length, data.length, 0)
+        const encoded = test.concat([length, data])
+
+        wrap.write(encoded)
+        try {
+          await wrap.readLP()
+          assert.fail("Should not be able to read too long msg data")
+        } catch (e) {
+          assert.ok(true);
+        }
+      })
+
+      it('lp max length decode', async () => {
+        const duplex = Pair()
+        const wrap = Wrap(duplex, { lengthDecoder: int32BEDecode, maxDataLength: 5000 })
+        const data = test.allocUnsafe(4000);
+        const length = test.allocUnsafe(4)
+        test.writeInt32BE(length, data.length, 0)
+        const encoded = test.concat([length, data])
+
+        wrap.write(encoded)
+        const res = await wrap.readLP()
+        assertBytesEqual(res, data)
+      })
+
+    })
+
+    describe('plain data', async () => {
+      it('whole', async () => {
+        const data = Buffer.from('ww')
+
+        w.write(data)
+        const res = await w.read(2)
+
+        assertBytesEqual(res, data)
+      })
+
+      it('split', async () => {
+        const data = Buffer.from('ww')
+
+        const r = Buffer.from('w')
+
+        w.write(data)
+        const r1 = await w.read(1)
+        const r2 = await w.read(1)
+
+        assertBytesEqual(r, r1)
+        assertBytesEqual(r, r2)
+      })
+    })
   })
 
-  describe('length-prefixed', () => {
-    it('lp varint', async () => {
-      const data = Buffer.from('hellllllllloooo')
-
-      w.writeLP(data)
-      const res = await w.readLP()
-      assert.deepEqual(data, res.slice())
-    })
-
-    it('lp fixed encode', async () => {
-      const duplex = Pair()
-      const wrap = Wrap(duplex, { lengthEncoder: int32BEEncode })
-      const data = Buffer.from('hellllllllloooo')
-
-      wrap.writeLP(data)
-      const res = await wrap.read()
-      const length = Buffer.allocUnsafe(4)
-      length.writeInt32BE(data.length, 0)
-      const expected = Buffer.concat([length, data])
-      assert.deepEqual(res.slice(), expected)
-    })
-
-    it('lp fixed decode', async () => {
-      const duplex = Pair()
-      const wrap = Wrap(duplex, { lengthDecoder: int32BEDecode })
-      const data = Buffer.from('hellllllllloooo')
-      const length = Buffer.allocUnsafe(4)
-      length.writeInt32BE(data.length, 0)
-      const encoded = Buffer.concat([length, data])
-
-      wrap.write(encoded)
-      const res = await wrap.readLP()
-      assert.deepEqual(res.slice(), data)
-    })
-
-    it('lp exceeds max length decode', async () => {
-      const duplex = Pair()
-      const wrap = Wrap(duplex, { lengthDecoder: int32BEDecode, maxDataLength: 32 })
-      const data = Buffer.alloc(33, 1);
-      const length = Buffer.allocUnsafe(4)
-      length.writeInt32BE(data.length, 0)
-      const encoded = Buffer.concat([length, data])
-
-      wrap.write(encoded)
-      try {
-        await wrap.readLP()
-        assert.fail("Should not be able to read too long msg data")
-      } catch (e) {
-        assert.ok(true);
-      }
-    })
-
-    it('lp max length decode', async () => {
-      const duplex = Pair()
-      const wrap = Wrap(duplex, { lengthDecoder: int32BEDecode, maxDataLength: 5000 })
-      const data = Buffer.allocUnsafe(4000);
-      const length = Buffer.allocUnsafe(4)
-      length.writeInt32BE(data.length, 0)
-      const encoded = Buffer.concat([length, data])
-
-      wrap.write(encoded)
-      const res = await wrap.readLP()
-      assert.deepEqual(res.slice(), data)
-    })
-
-  })
-
-  describe('plain data', async () => {
-    it('whole', async () => {
-      const data = Buffer.from('ww')
-
-      w.write(data)
-      const r = await w.read(2)
-
-      assert.deepEqual(data, r.slice())
-    })
-
-    it('split', async () => {
-      const data = Buffer.from('ww')
-
-      const r = Buffer.from('w')
-
-      w.write(data)
-      const r1 = await w.read(1)
-      const r2 = await w.read(1)
-
-      assert.deepEqual(r, r1.slice())
-      assert.deepEqual(r, r2.slice())
-    })
-  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -13,8 +13,8 @@ const { Buffer } = require('buffer')
 /* eslint-disable require-await */
 
 const assertBytesEqual = (a, b) => {
-  a = a.slice()
-  b = b.slice()
+  a = a instanceof Uint8Array ? a : a.slice()
+  b = b instanceof Uint8Array ? b : b.slice()
 
   for (let i = 0; i < a.length; i++) {
     if (a[i] !== b[i]) {


### PR DESCRIPTION
Changes the types to deal in browser-friendly `Uint8Array`s instead of node `Buffer`s as well as `BufferList`s, but also refactors the tests to make sure it supports all three.